### PR TITLE
🐛 fix: SignInServlet session issue

### DIFF
--- a/src/java/techmart/SignInServlet.java
+++ b/src/java/techmart/SignInServlet.java
@@ -57,7 +57,7 @@ public class SignInServlet extends HttpServlet {
             ResultSet result=ps.executeQuery();
             if(result.next()){
                 HttpSession session=request.getSession();
-                session.setAttribute(email, email);
+                session.setAttribute("email", email);
                 session.setMaxInactiveInterval(86400);
                 response.sendRedirect("index.jsp");
             }else{


### PR DESCRIPTION
## Issue Resolved:
The issue with the SignInServlet not creating new sessions after user login has been successfully fixed.

## Description of Fix:
Upon investigation, it was discovered that the session creation logic in the SignInServlet was not being triggered correctly after successful user authentication. This was due to a missing double quotes between email and fixed #8 by `session.setAttribute(email, email);` ==> `session.setAttribute("email", email);`